### PR TITLE
Dsp 774 - define persistence config for google redis instance

### DIFF
--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -7,7 +7,7 @@ resource "google_redis_instance" "main" {
   region  = var.region
   name    = var.name
 
-  redis_version  = "REDIS_7_2"
+  redis_version = "REDIS_7_2"
 
   memory_size_gb = 2
 

--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -7,9 +7,9 @@ resource "google_redis_instance" "main" {
   region  = var.region
   name    = var.name
 
-  redis_version = "REDIS_7_2"
+  redis_version = var.version
 
-  memory_size_gb = 2
+  memory_size_gb = var.memory
 
   authorized_network = var.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
@@ -17,8 +17,8 @@ resource "google_redis_instance" "main" {
   auth_enabled = true
 
   persistence_config {
-    persistence_mode    = "RDB"
-    rdb_snapshot_period = "ONE_HOUR"
+    persistence_mode    = var.persistence_mode
+    rdb_snapshot_period = var.persistence_period
   }
 
   depends_on = [

--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -14,6 +14,11 @@ resource "google_redis_instance" "main" {
 
   auth_enabled = true
 
+  persistence_config {
+    persistence_mode    = "RDB"
+    rdb_snapshot_period = "ONE_HOUR"
+  }
+
   depends_on = [
     google_project_service.redis,
   ]

--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -7,7 +7,7 @@ resource "google_redis_instance" "main" {
   region  = var.region
   name    = var.name
 
-  memory_size_gb = 1
+  memory_size_gb = 2
 
   authorized_network = var.network
   connect_mode       = "PRIVATE_SERVICE_ACCESS"

--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -7,6 +7,8 @@ resource "google_redis_instance" "main" {
   region  = var.region
   name    = var.name
 
+  redis_version  = "REDIS_7_2"
+
   memory_size_gb = 2
 
   authorized_network = var.network

--- a/google/redis/variables.tf
+++ b/google/redis/variables.tf
@@ -42,15 +42,15 @@ variable "version" {
 
 variable "memory" {
   type    = number
-  default = 2
+  default = 1
 }
 
 variable "persistence_mode" {
   type    = string
-  default = "RDB"
+  default = "DISABLED"
 }
 
 variable "persistence_period" {
   type    = string
-  default = "ONE_HOUR"
+  default = null
 }

--- a/google/redis/variables.tf
+++ b/google/redis/variables.tf
@@ -34,3 +34,23 @@ variable "cluster" {
 variable "network" {
   type = string
 }
+
+variable "version" {
+  type    = string
+  default = "REDIS_7_2"
+}
+
+variable "memory" {
+  type    = number
+  default = 2
+}
+
+variable "persistence_mode" {
+  type    = string
+  default = "RDB"
+}
+
+variable "persistence_period" {
+  type    = string
+  default = "ONE_HOUR"
+}


### PR DESCRIPTION
[DSP-774]

This pull request includes updates to the `google_for_redis` resource configuration:

Configuration updates:

* Set `redis_version` to "REDIS_7_2", the latest supported version as per https://cloud.google.com/memorystore/docs/redis/supported-versions#redis_version_72.
* Increased the `memory_size_gb` from 1 to 2 to allocate more memory, this also matches the config in our soon-to-be-deprecated chef redis instance. https://github.com/remerge/chef.new/blob/e105396e9af65999a39a76f3cc344fb190a3939a/cookbooks/db/recipes/redis.rb#L8

Persistence configuration:

* Added a `persistence_config` block to enable RDB persistence with a snapshot period of one hour. (rdb persistence is currently used by our chef redis)

[DSP-774]: https://remerge.atlassian.net/browse/DSP-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ