### PR TITLE
DSP-774-fix-error-using-reserved-name-for-var

### DIFF
--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -7,7 +7,7 @@ resource "google_redis_instance" "main" {
   region  = var.region
   name    = var.name
 
-  redis_version = var.version
+  redis_version = var.redis_version
 
   memory_size_gb = var.memory
 

--- a/google/redis/variables.tf
+++ b/google/redis/variables.tf
@@ -35,7 +35,7 @@ variable "network" {
   type = string
 }
 
-variable "version" {
+variable "redis_version" {
   type    = string
   default = "REDIS_7_2"
 }


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DSP-774
The variable name "version" is reserved due to its special meaning inside module blocks.