### PR TITLE
DSP-804- Add a maxmemory_policy variable to the google/redis module

### DIFF
--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -21,6 +21,10 @@ resource "google_redis_instance" "main" {
     rdb_snapshot_period = var.persistence_period
   }
 
+  redis_configs = {
+    maxmemory_policy = var.maxmemory_policy
+  }
+
   depends_on = [
     google_project_service.redis,
   ]

--- a/google/redis/variables.tf
+++ b/google/redis/variables.tf
@@ -54,3 +54,8 @@ variable "persistence_period" {
   type    = string
   default = null
 }
+
+variable "maxmemory_policy" {
+  type    = string
+  default = "volatile-lru"
+}


### PR DESCRIPTION
[DSP-804]
maxmemory_policy for redis_config by Memorystore defaults to `volatile-lru` as in documentation: https://cloud.google.com/memorystore/docs/redis/supported-redis-configurations#:~:text=The%20default%20maxmemory%20policy%20for,overwrite%20or%20evict%20any%20data.

[DSP-804]: https://remerge.atlassian.net/browse/DSP-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ