### PR TITLE
DSP-804 Fix config param name

### DIFF
--- a/google/redis/main.tf
+++ b/google/redis/main.tf
@@ -22,7 +22,7 @@ resource "google_redis_instance" "main" {
   }
 
   redis_configs = {
-    maxmemory_policy = var.maxmemory_policy
+    maxmemory-policy = var.maxmemory_policy
   }
 
   depends_on = [


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DSP-804
Using hyphens as redis_configs is mapped to the expected config params of redis that use hyphens.


IMPORTANT: API should reference the latest master once this is merged. 