### PR TITLE
Read Nomad groups from group_list OIDC claim

### DIFF
--- a/nomad/base/main.tf
+++ b/nomad/base/main.tf
@@ -50,7 +50,7 @@ resource "nomad_acl_auth_method" "okta" {
     }
 
     list_claim_mappings = {
-      groups = "groups"
+      group_list = "groups"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Map Okta's new `group_list` claim into Nomad's `list.groups` ACL variable
- Existing policy selectors (`"Core Platform Team" in list.groups`, etc.) keep working — only the source claim name changes
- Pairs with https://github.com/remerge/okta/pull/167, which adds the `okta_app_federated_claim` named `group_list` to the Nomad Okta app

## Test plan
- [ ] Apply the okta PR first so the `group_list` claim is issued before this module change rolls out
- [ ] Verify Nomad login via Okta still produces ACL tokens for `Core Platform Team`, `Data Platform Team`, and `On-Call Team` members
- [ ] Confirm `oidc_scopes` still includes `groups` (left in place; harmless if no longer issued)

🤖 Generated with [Claude Code](https://claude.com/claude-code)