### PR TITLE
Shorten Nomad OIDC token name to just the email

### DIFF
--- a/nomad/base/main.tf
+++ b/nomad/base/main.tf
@@ -29,7 +29,7 @@ resource "nomad_acl_auth_method" "okta" {
   max_token_ttl  = var.auth_max_token_ttl
   default        = true
 
-  token_name_format = "$${auth_method_type}-$${auth_method_name}-$${value.email}"
+  token_name_format = "$${value.email}"
 
   config {
     oidc_discovery_url = var.okta_discovery_url


### PR DESCRIPTION
## Summary
- Drop the `OIDC-Okta-` prefix from the auto-generated Nomad ACL token name format
- Tokens will display as just the user's email in the Nomad UI and CLI

## Test plan
- [ ] Log into a Nomad cluster via Okta and confirm the resulting ACL token's name is the user's email address only

🤖 Generated with [Claude Code](https://claude.com/claude-code)