### PR TITLE
Bind Nomad root role via derived role claim

### DIFF
--- a/nomad/base/main.tf
+++ b/nomad/base/main.tf
@@ -47,7 +47,7 @@ resource "nomad_acl_auth_method" "okta" {
       first_name = "first_name"
       last_name  = "last_name"
       email      = "email"
-      role       = "role"
+      nomad_role = "role"
     }
   }
 }

--- a/nomad/base/main.tf
+++ b/nomad/base/main.tf
@@ -35,7 +35,7 @@ resource "nomad_acl_auth_method" "okta" {
     oidc_discovery_url = var.okta_discovery_url
     oidc_client_id     = data.onepassword_item.nomad_oidc_client.username
     oidc_client_secret = data.onepassword_item.nomad_oidc_client.password
-    oidc_scopes        = ["profile", "groups", "email"]
+    oidc_scopes        = ["profile", "email"]
 
     allowed_redirect_uris = [
       "http://localhost:4649/oidc/callback",
@@ -47,10 +47,7 @@ resource "nomad_acl_auth_method" "okta" {
       first_name = "first_name"
       last_name  = "last_name"
       email      = "email"
-    }
-
-    list_claim_mappings = {
-      group_list = "groups"
+      nomad_role = "nomad_role"
     }
   }
 }
@@ -170,30 +167,11 @@ resource "nomad_acl_role" "root" {
   }
 }
 
-moved {
-  from = nomad_acl_binding_rule.platform
-  to   = nomad_acl_binding_rule.core
-}
-
-resource "nomad_acl_binding_rule" "core" {
+resource "nomad_acl_binding_rule" "root" {
   auth_method = nomad_acl_auth_method.okta.name
   bind_type   = "role"
   bind_name   = nomad_acl_role.root.name
-  selector    = "\"Core Platform Team\" in list.groups"
-}
-
-resource "nomad_acl_binding_rule" "data" {
-  auth_method = nomad_acl_auth_method.okta.name
-  bind_type   = "role"
-  bind_name   = nomad_acl_role.root.name
-  selector    = "\"Data Platform Team\" in list.groups"
-}
-
-resource "nomad_acl_binding_rule" "oncall" {
-  auth_method = nomad_acl_auth_method.okta.name
-  bind_type   = "role"
-  bind_name   = nomad_acl_role.root.name
-  selector    = "\"On-Call Team\" in list.groups"
+  selector    = "value.nomad_role == \"root\""
 }
 
 resource "nomad_acl_policy" "github_actions" {

--- a/nomad/base/main.tf
+++ b/nomad/base/main.tf
@@ -47,7 +47,7 @@ resource "nomad_acl_auth_method" "okta" {
       first_name = "first_name"
       last_name  = "last_name"
       email      = "email"
-      nomad_role = "nomad_role"
+      role       = "role"
     }
   }
 }
@@ -171,7 +171,7 @@ resource "nomad_acl_binding_rule" "root" {
   auth_method = nomad_acl_auth_method.okta.name
   bind_type   = "role"
   bind_name   = nomad_acl_role.root.name
-  selector    = "value.nomad_role == \"root\""
+  selector    = "value.role == \"root\""
 }
 
 resource "nomad_acl_policy" "github_actions" {


### PR DESCRIPTION
## Summary
- Replaces the three team-name ACL binding rules (`core`, `data`, `oncall`) with a single rule selecting on `value.nomad_role == "root"`
- The team→role mapping is now done in Okta (see remerge/okta#168) and emitted as a derived `nomad_role` claim
- Drops the now-unused `groups` OIDC scope and `list_claim_mappings`

## Why
The mapping from Okta team membership to Nomad role lived inside this terraform module, so adding or rotating a "root-eligible" team meant editing the module and re-applying every downstream cluster. With the derived claim, that policy lives in Okta and downstream Nomad clusters only need to know "root means role=root".

## Dependencies
Apply remerge/okta#168 **first** so the `nomad_role` claim is being issued before this module change rolls out.

## Test plan
- [ ] Apply okta#168
- [ ] Apply this PR to each Nomad cluster
- [ ] Login via Okta as a Core Platform / Data Platform / On-Call team member — confirm `root` role is bound on the resulting ACL token
- [ ] Login as a regular user — confirm only the `default` role is bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)