### PR TITLE
Add availability_type variable to postgresql module

### DIFF
--- a/google/sql/postgresql/main.tf
+++ b/google/sql/postgresql/main.tf
@@ -32,7 +32,7 @@ resource "google_sql_database_instance" "main" {
       }
     }
 
-    availability_type = "REGIONAL"
+    availability_type = var.availability_type
 
     backup_configuration {
       enabled  = true

--- a/google/sql/postgresql/variables.tf
+++ b/google/sql/postgresql/variables.tf
@@ -21,6 +21,15 @@ variable "tier" {
   default = "db-f1-micro"
 }
 
+variable "availability_type" {
+  type    = string
+  default = "REGIONAL"
+  validation {
+    condition     = contains(["REGIONAL", "ZONAL"], var.availability_type)
+    error_message = "availability_type must be either REGIONAL or ZONAL."
+  }
+}
+
 variable "network" {
   type = string
 }


### PR DESCRIPTION
## Summary

- Expose Cloud SQL `availability_type` as a module variable.
- Default to `REGIONAL` to preserve current behavior; validate against `[REGIONAL, ZONAL]`.

## Why

Some workloads (e.g. NetBox in `remerge/network`) don't need cross-zone HA and pay for it in price/latency. Making this configurable lets callers opt down to `ZONAL` per instance.

## Test plan

- [ ] Existing callers default to `REGIONAL` and `terraform plan` is a no-op
- [ ] Setting `availability_type = "ZONAL"` flips the underlying `google_sql_database_instance` setting (downstream test in `remerge/network`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)