### PR TITLE
DATA-1392 Guarantee Leaseweb install password meets complexity requirements

### DIFF
--- a/leaseweb/server/installation/main.tf
+++ b/leaseweb/server/installation/main.tf
@@ -3,10 +3,23 @@ resource "random_password" "main" {
   special          = true
   override_special = "@,.^%-_~"
 
+  # Leaseweb's installation API rejects passwords that don't contain at least
+  # one of each character class (upper, lower, digit, special). Without these
+  # minimums random_password occasionally generates a value missing a class,
+  # which fails the install mid-apply. Guarantee one of each.
+  min_upper   = 1
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
+
   lifecycle {
     ignore_changes = [
       special,
       override_special,
+      min_upper,
+      min_lower,
+      min_numeric,
+      min_special,
     ]
   }
 }


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DATA-1392
## Problem

`module "leaseweb/server/installation"`'s `random_password.main` is length-16 but leaves every character class **optional** (`min_upper`/`min_lower`/`min_numeric`/`min_special` all default to 0). Leaseweb's installation API requires a password with **at least one uppercase, one lowercase, one digit, and one special character** and rejects anything else with:

> `Password must be at least 12 characters long, must have at least one uppercase, one lowercase, one digit and one special character`

So roughly 15–20% of generated passwords (dominated by ~14% chance of no special char) are rejected, failing the install **mid-apply**. This just bit the dw-cluster ClickHouse expansion: 2 of 16 servers (`ch27`, `ch35`) failed and had to be re-rolled by hand.

## Fix

Set `min_upper = min_lower = min_numeric = min_special = 1` so every generated password is guaranteed to satisfy the policy (4 required classes ≤ 16 chars).

The minimums are also added to `lifecycle.ignore_changes` (alongside the existing `special`/`override_special`), so this change **does not regenerate passwords for already-provisioned servers** — `ignore_changes` suppresses the diff on existing resources while still applying the constraints at creation time for new ones. No reinstalls, no churn across existing `ch`/`chi`/`drn`/etc. consumers.

## Verification

- `pre-commit run` passes (`tofu-fmt`, `tofu-validate`).
- `min_*` are standard `hashicorp/random` `random_password` arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkdL2rWUUfiUmNzCL93xr6