### PR TITLE
IT-8932: Use Remerge leaseweb provider fork from private registry

### DIFF
--- a/leaseweb/server/installation/versions.tf
+++ b/leaseweb/server/installation/versions.tf
@@ -1,8 +1,11 @@
 terraform {
   required_providers {
-    # https://registry.terraform.io/providers/LeaseWeb/leaseweb/latest
+    # Remerge fork of https://registry.terraform.io/providers/LeaseWeb/leaseweb
+    # published to the HCP Terraform private registry: tolerates the broken
+    # DHCP leases endpoint (503) on private rack servers.
+    # https://github.com/remerge/terraform-provider-leaseweb
     leaseweb = {
-      source = "LeaseWeb/leaseweb"
+      source = "app.terraform.io/remerge/leaseweb"
     }
   }
 }

--- a/leaseweb/server/installation/versions.tf
+++ b/leaseweb/server/installation/versions.tf
@@ -6,6 +6,8 @@ terraform {
     # https://github.com/remerge/terraform-provider-leaseweb
     leaseweb = {
       source = "app.terraform.io/remerge/leaseweb"
+      # prerelease: pin exactly, other constraints exclude prereleases
+      version = "1.31.1-remerge1"
     }
   }
 }

--- a/netbox/device/main.tf
+++ b/netbox/device/main.tf
@@ -20,6 +20,12 @@ resource "netbox_device" "main" {
   lifecycle {
     ignore_changes = [
       serial,
+      # rack placement is documented directly in NetBox and not managed by
+      # this module; without this an imported device loses its rack elevation
+      location_id,
+      rack_id,
+      rack_position,
+      rack_face,
     ]
   }
 }

--- a/op/host/leaseweb/versions.tf
+++ b/op/host/leaseweb/versions.tf
@@ -10,6 +10,8 @@ terraform {
     # https://github.com/remerge/terraform-provider-leaseweb
     leaseweb = {
       source = "app.terraform.io/remerge/leaseweb"
+      # prerelease: pin exactly, other constraints exclude prereleases
+      version = "1.31.1-remerge1"
     }
   }
 }

--- a/op/host/leaseweb/versions.tf
+++ b/op/host/leaseweb/versions.tf
@@ -4,9 +4,12 @@ terraform {
     onepassword = {
       source = "1Password/onepassword"
     }
-    # https://registry.terraform.io/providers/LeaseWeb/leaseweb/latest
+    # Remerge fork of https://registry.terraform.io/providers/LeaseWeb/leaseweb
+    # published to the HCP Terraform private registry: tolerates the broken
+    # DHCP leases endpoint (503) on private rack servers.
+    # https://github.com/remerge/terraform-provider-leaseweb
     leaseweb = {
-      source = "LeaseWeb/leaseweb"
+      source = "app.terraform.io/remerge/leaseweb"
     }
   }
 }


### PR DESCRIPTION
The Leaseweb API returns a persistent 503 from `GET /bareMetals/v2/servers/{id}/leases` for some private rack servers (e.g. hv01.dw2, server 12022420), which makes the upstream provider abort every read/import of such servers. The Remerge fork [`app.terraform.io/remerge/leaseweb` 1.31.1-remerge1](https://github.com/remerge/terraform-provider-leaseweb) treats 404/503 from that endpoint as "no DHCP lease" (with a warning) instead.

This switches `op/host/leaseweb` and `leaseweb/server/installation` to the fork. Consumers must configure the forked provider in their root module when they upgrade to this version — remerge/network does so for the import of the dw2 private rack hypervisors (IT-8932).

Also makes `netbox/device` ignore rack placement attributes (location, rack, position, face): importing a device with placement data used to plan its removal (hv03.dw2 lost its rack elevation this way in January).

remerge/network#276 consumes this PR's head commit by SHA (`17f0e91`); tag the next release (v0.41.0) after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Y15M9koLw6McFMZdwBbM9